### PR TITLE
 Add colors to passed and failed messages

### DIFF
--- a/bashunit
+++ b/bashunit
@@ -2,6 +2,9 @@
 
 readonly BASH_UNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
+# Load color configuration
+source "$BASH_UNIT_ROOT_DIR/src/colors.sh"
+
 # Load all assert functions
 source "$BASH_UNIT_ROOT_DIR/src/assert.sh"
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -30,11 +30,11 @@ assertEquals() {
 
   if [[ "$expected" != "$actual" ]]; then
     FAILED=true
-    printf "❌  %s failed:\\n Expected '%s'\\n but got  '%s'\\n" "$label" "$expected" "$actual"
+    printf "❌  ${COLOR_FAILED}Failed${COLOR_DEFAULT}: %s\\n Expected '%s'\\n but got  '%s'\\n" "$label" "$expected" "$actual"
     exit 1
   else
     ((TOTAL_TESTS++))
-    printf "✔️  Passed: %s\\n" "$label"
+    printf "✔️  ${COLOR_PASSED}Passed${COLOR_DEFAULT}: %s\\n" "$label"
   fi
 }
 

--- a/src/colors.sh
+++ b/src/colors.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export COLOR_FAILED="\e[31m"
+export COLOR_PASSED="\e[32m"
+export COLOR_DEFAULT="\e[0m"

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 function test_successful_assertEquals() {
-  assertEquals "✔️  Passed: Successful assertEquals" "$(assertEquals "1" "1")"
+  assertEquals "$(printf "✔️  ${COLOR_PASSED}Passed${COLOR_DEFAULT}: Successful assertEquals")" "$(assertEquals "1" "1")"
 }
 
 function test_unsuccessful_assertEquals() {
-  assertEquals "❌  Unsuccessful assertEquals failed:
+  assertEquals "$(printf "❌  ${COLOR_FAILED}Failed${COLOR_DEFAULT}: Unsuccessful assertEquals
  Expected '1'
- but got  '2'" "$(assertEquals "1" "2")"
+ but got  '2'")" "$(assertEquals "1" "2")"
 }
 
 function testCamelCase() {
-  assertEquals "✔️  Passed: CamelCase" "$(assertEquals "1" "1")"
+  assertEquals "$(printf "✔️  ${COLOR_PASSED}Passed${COLOR_DEFAULT}: CamelCase")" "$(assertEquals "1" "1")"
 }


### PR DESCRIPTION
Example:

![imagen](https://github.com/Chemaclass/bashunit/assets/13595197/d3f24439-74b5-49d9-9514-357fcb1f584d)

If it's okay I would also remove the emojis, since they don't have good support on all operating systems/fonts.

Personally, the terminals have many formatting options; take a look at how [Jest.js](https://jestjs.io) uses them.