### PR TITLE
chore: created assertNotContains not using the other assertion

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -56,6 +56,24 @@ assertContains() {
   esac
 }
 
+assertNotContains() {
+  local expected="$1"
+    local actual="$2"
+    local label="${3:-$(transformTestFunctionName ${FUNCNAME[1]})}"
+
+    case "$actual" in
+      *"$expected"*)
+        FAILED=true
+        printf "❌  ${COLOR_FAILED}Failed${COLOR_DEFAULT}: %s\\n Expected   '%s'\\n to not contain '%s'\\n" "$label" "$actual" "$expected"
+        exit 1
+        ;;
+      *)
+        ((TOTAL_TESTS++))
+        printf "✔️  ${COLOR_PASSED}Passed${COLOR_DEFAULT}: %s\\n" "$label"
+        ;;
+    esac
+}
+
 renderResult() {
   echo ""
   if [[ "$FAILED" == false ]]; then

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -4,6 +4,7 @@ export TEST=true
 
 export assertEquals
 export assertContains
+export assertNotContains
 
 TOTAL_TESTS=0
 FAILED=false

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -23,3 +23,13 @@ function test_unsuccessful_assertContains() {
  Expected   'GNU/Linux'
  to contain 'Unix'")" "$(assertContains "Unix" "GNU/Linux")"
 }
+
+function test_successful_assertNotContains() {
+  assertEquals "$(printf "✔️  ${COLOR_PASSED}Passed${COLOR_DEFAULT}: Successful assertNotContains")" "$(assertNotContains "Linus" "GNU/Linux")"
+}
+
+function test_unsuccessful_assertNotContains() {
+  assertEquals "$(printf "❌  ${COLOR_FAILED}Failed${COLOR_DEFAULT}: Unsuccessful assertNotContains
+ Expected   'GNU/Linux'
+ to not contain 'Linux'")" "$(assertNotContains "Linux" "GNU/Linux")"
+}


### PR DESCRIPTION
I've added the `assertNotContains` funtion to the framwork, not using the `assertContains` to don't make any test fail for dependency between functions