### PR TITLE
Allow ignoring a test using a comment skip

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -2,6 +2,7 @@
 
 export TEST=true
 
+export normalizeFnName
 export assertEquals
 export assertContains
 export assertNotContains

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -4,6 +4,11 @@ function test_successful_assertEquals() {
   assertEquals "$(printf "✔️  ${COLOR_PASSED}Passed${COLOR_DEFAULT}: Successful assertEquals")" "$(assertEquals "1" "1")"
 }
 
+function test_ignore_failing_test() {
+  # skip
+  assertEquals "1" "2"
+}
+
 function test_unsuccessful_assertEquals() {
   assertEquals "$(printf "❌  ${COLOR_FAILED}Failed${COLOR_DEFAULT}: Unsuccessful assertEquals
  Expected '1'


### PR DESCRIPTION
## 📚 Description

Allow skip/ignore an actual test if inside the test function there is a comment like `# skip`

```bash
function test_ignore_failing_test() {
  # skip
  assertEquals "1" "2"
}
```

<img width="892" alt="Screenshot 2023-09-07 at 22 23 13" src="https://github.com/Chemaclass/bashunit/assets/5256287/9d2effdb-6db5-4363-acb6-5d834eba1284">
