### PR TITLE
chore: added assert matches, refactor global variables to start with underscored and add watch to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,7 @@ list-tests:
 test: $(TEST_SCRIPTS)
 	./bashunit $(TEST_SCRIPTS)
 
+test/watch: $(TEST_SCRIPTS)
+	watch --color -n 1 ./bashunit $(TEST_SCRIPTS)
+
 .PHONY: test list-tests

--- a/bashunit
+++ b/bashunit
@@ -8,5 +8,8 @@ source "$BASH_UNIT_ROOT_DIR/src/colors.sh"
 # Load all assert functions
 source "$BASH_UNIT_ROOT_DIR/src/assert.sh"
 
+# Load results to the TTY
+source "$BASH_UNIT_ROOT_DIR/src/console_results.sh"
+
 # Execute the test runner
 source "$BASH_UNIT_ROOT_DIR/src/test_runner.sh" "$@"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -6,10 +6,9 @@ export assertEquals
 export assertContains
 export assertNotContains
 export assertMatches
-export renderResult
 
-_TOTAL_FAILED=0
-_TOTAL_PASSED=0
+_TOTAL_ASSERTIONS_FAILED=0
+_TOTAL_ASSERTIONS_PASSED=0
 
 normalizeFnName() {
   local originalFnName="$1"
@@ -33,13 +32,13 @@ assertEquals() {
   local label="${3:-$(normalizeFnName ${FUNCNAME[1]})}"
 
   if [[ "$expected" != "$actual" ]]; then
-    ((_TOTAL_FAILED++))
+    ((_TOTAL_ASSERTIONS_FAILED++))
     printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${expected}'${COLOR_DEFAULT}
     ${COLOR_FAINT}but got${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}\n"
   else
-    ((_TOTAL_PASSED++))
+    ((_TOTAL_ASSERTIONS_PASSED++))
     printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
   fi
 }
@@ -51,11 +50,11 @@ assertContains() {
 
   case "$actual" in
     *"$expected"*)
-      ((_TOTAL_PASSED++))
+      ((_TOTAL_ASSERTIONS_PASSED++))
       printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
       ;;
     *)
-      ((_TOTAL_FAILED++))
+      ((_TOTAL_ASSERTIONS_FAILED++))
       printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}
@@ -72,7 +71,7 @@ assertNotContains() {
 
     case "$actual" in
       *"$expected"*)
-        ((_TOTAL_FAILED++))
+        ((_TOTAL_ASSERTIONS_FAILED++))
         printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}
@@ -80,7 +79,7 @@ ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
         exit 1
         ;;
       *)
-        ((_TOTAL_PASSED++))
+        ((_TOTAL_ASSERTIONS_PASSED++))
         printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
         ;;
     esac
@@ -92,10 +91,10 @@ assertMatches() {
   local label="${3:-$(normalizeFnName ${FUNCNAME[1]})}"
 
   if [[ $actual =~ $expected ]]; then
-    ((_TOTAL_PASSED++))
+    ((_TOTAL_ASSERTIONS_PASSED++))
     printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
   else
-    ((_TOTAL_FAILED++))
+    ((_TOTAL_ASSERTIONS_FAILED++))
           printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}
@@ -103,25 +102,3 @@ ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     exit 1
   fi
 }
-
-function renderResult() {
-  local totalTests=$1
-  local totalPassed=$2
-  local totalFailed=$3
-
-  echo ""
-  local totalAssertions=$((totalPassed + totalFailed))
-  printf "\
-${COLOR_FAINT}Total tests:${COLOR_DEFAULT} ${COLOR_BOLD}${totalTests}${COLOR_DEFAULT}
-${COLOR_FAINT}Total assertions:${COLOR_DEFAULT} ${COLOR_BOLD}${totalAssertions}${COLOR_DEFAULT}\n"
-
-  if [ "$totalFailed" -gt 0 ]; then
-    printf "${COLOR_FAINT}Total assertions failed:${COLOR_DEFAULT} ${COLOR_BOLD}${COLOR_FAILED}${totalFailed}${COLOR_DEFAULT}\n"
-    exit 1
-  else
-    printf "${COLOR_ALL_PASSED}All assertions passed.${COLOR_DEFAULT}\n"
-  fi
-}
-
-# Set a trap to call render_result when the script exits
-trap 'renderResult $_TOTAL_TESTS $_TOTAL_PASSED $_TOTAL_FAILED' EXIT

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -5,10 +5,11 @@ export TEST=true
 export assertEquals
 export assertContains
 export assertNotContains
+export assertMatches
 export renderResult
 
-TOTAL_FAILED=0
-TOTAL_PASSED=0
+_TOTAL_FAILED=0
+_TOTAL_PASSED=0
 
 normalizeFnName() {
   local originalFnName="$1"
@@ -32,13 +33,13 @@ assertEquals() {
   local label="${3:-$(normalizeFnName ${FUNCNAME[1]})}"
 
   if [[ "$expected" != "$actual" ]]; then
-    ((TOTAL_FAILED++))
+    ((_TOTAL_FAILED++))
     printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${expected}'${COLOR_DEFAULT}
     ${COLOR_FAINT}but got${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}\n"
   else
-    ((TOTAL_PASSED++))
+    ((_TOTAL_PASSED++))
     printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
   fi
 }
@@ -50,11 +51,11 @@ assertContains() {
 
   case "$actual" in
     *"$expected"*)
-      ((TOTAL_PASSED++))
+      ((_TOTAL_PASSED++))
       printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
       ;;
     *)
-      ((TOTAL_FAILED++))
+      ((_TOTAL_FAILED++))
       printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}
@@ -71,7 +72,7 @@ assertNotContains() {
 
     case "$actual" in
       *"$expected"*)
-        ((TOTAL_FAILED++))
+        ((_TOTAL_FAILED++))
         printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}
@@ -79,10 +80,28 @@ ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
         exit 1
         ;;
       *)
-        ((TOTAL_PASSED++))
+        ((_TOTAL_PASSED++))
         printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
         ;;
     esac
+}
+
+assertMatches() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-$(normalizeFnName ${FUNCNAME[1]})}"
+
+  if [[ $actual =~ $expected ]]; then
+    ((_TOTAL_PASSED++))
+    printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
+  else
+    ((_TOTAL_FAILED++))
+          printf "\
+${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
+    ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}
+    ${COLOR_FAINT}to match${COLOR_DEFAULT} ${COLOR_BOLD}'${expected}'${COLOR_DEFAULT}\n"
+    exit 1
+  fi
 }
 
 function renderResult() {
@@ -105,4 +124,4 @@ ${COLOR_FAINT}Total assertions:${COLOR_DEFAULT} ${COLOR_BOLD}${totalAssertions}$
 }
 
 # Set a trap to call render_result when the script exits
-trap 'renderResult $TOTAL_TESTS $TOTAL_PASSED $TOTAL_FAILED' EXIT
+trap 'renderResult $_TOTAL_TESTS $_TOTAL_PASSED $_TOTAL_FAILED' EXIT

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -19,5 +19,5 @@ ${COLOR_FAINT}Total assertions:${COLOR_DEFAULT} ${COLOR_BOLD}${totalAssertions}$
   fi
 }
 
-# Set a trap to call render_result when the script exits
+# Set a trap to call renderResult when the script exits
 trap 'renderResult $_TOTAL_TESTS $_TOTAL_ASSERTIONS_PASSED $_TOTAL_ASSERTIONS_FAILED' EXIT

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -1,0 +1,23 @@
+export renderResult
+
+function renderResult() {
+  local totalTests=$1
+  local totalPassed=$2
+  local totalFailed=$3
+
+  echo ""
+  local totalAssertions=$((totalPassed + totalFailed))
+  printf "\
+${COLOR_FAINT}Total tests:${COLOR_DEFAULT} ${COLOR_BOLD}${totalTests}${COLOR_DEFAULT}
+${COLOR_FAINT}Total assertions:${COLOR_DEFAULT} ${COLOR_BOLD}${totalAssertions}${COLOR_DEFAULT}\n"
+
+  if [ "$totalFailed" -gt 0 ]; then
+    printf "${COLOR_FAINT}Total assertions failed:${COLOR_DEFAULT} ${COLOR_BOLD}${COLOR_FAILED}${totalFailed}${COLOR_DEFAULT}\n"
+    exit 1
+  else
+    printf "${COLOR_ALL_PASSED}All assertions passed.${COLOR_DEFAULT}\n"
+  fi
+}
+
+# Set a trap to call render_result when the script exits
+trap 'renderResult $_TOTAL_TESTS $_TOTAL_ASSERTIONS_PASSED $_TOTAL_ASSERTIONS_FAILED' EXIT

--- a/src/test_runner.sh
+++ b/src/test_runner.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-export TOTAL_TESTS
+export _TOTAL_TESTS
 
-TOTAL_TESTS=0
+_TOTAL_TESTS=0
 
 # shellcheck disable=SC2155
 # shellcheck disable=SC2034
@@ -30,7 +30,7 @@ callTestFunctions() {
   if [ "${#functions_to_run[@]}" -gt 0 ]; then
     echo "Running $script"
     for func_name in "${functions_to_run[@]}"; do
-      ((TOTAL_TESTS++))
+      ((_TOTAL_TESTS++))
       "$func_name"  # Call the function
       unset "$func_name"
     done

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -45,3 +45,15 @@ ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: Unsuccessful assertNotContains
     ${COLOR_FAINT}to not contain${COLOR_DEFAULT} ${COLOR_BOLD}'Linux'${COLOR_DEFAULT}
 ")" "$(assertNotContains "Linux" "GNU/Linux")"
 }
+
+function test_successful_assertMatches() {
+  assertEquals "$(printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: Successful assertMatches")" "$(assertMatches ".*Linu*" "GNU/Linux")"
+}
+
+function test_unsuccessful_assertMatches() {
+  assertEquals "$(printf "\
+${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: Unsuccessful assertMatches
+    ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'GNU/Linux'${COLOR_DEFAULT}
+    ${COLOR_FAINT}to match${COLOR_DEFAULT} ${COLOR_BOLD}'.*Pinux*'${COLOR_DEFAULT}
+")" "$(assertMatches ".*Pinux*" "GNU/Linux")"
+}


### PR DESCRIPTION
Related to: https://github.com/Chemaclass/bashunit/issues/23

Allow asserting by using regular expressions:

```bash
assertMatches ".*Pinux*" "GNU/Linux"
```