### PR TITLE
Remove Time taken feature from non-Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added `assertMatches`
 - Added `assertNotMatches`
 - Added `make test/watch` to run your test every second
-- Added time taken to run the test in ms
+- Added time taken to run the test in ms (only to Linux)
 
 ### 0.4.0
 ### 2023-09-08

--- a/bashunit
+++ b/bashunit
@@ -2,6 +2,16 @@
 
 readonly BASH_UNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
+OS="Unknown"
+
+if [ "$(uname)" == "Linux" ]; then
+    OS="Linux"
+elif [ "$(uname)" == "Darwin" ]; then
+    OS="OSX"
+elif [[ $(uname) == *"MINGW"* ]]; then
+    OS="Windows"
+fi
+
 # Load color configuration
 source "$BASH_UNIT_ROOT_DIR/src/colors.sh"
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -105,20 +105,19 @@ ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
 }
 
 assertNotMatches() {
-    local expected="$1"
-    local actual="$2"
-    local label="${3:-$(normalizeFnName ${FUNCNAME[1]})}"
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-$(normalizeFnName ${FUNCNAME[1]})}"
 
-    if [[ $actual =~ $expected ]]; then
-      ((_TOTAL_ASSERTIONS_FAILED++))
-            printf "\
+  if [[ $actual =~ $expected ]]; then
+    ((_TOTAL_ASSERTIONS_FAILED++))
+    printf "\
 ${COLOR_FAILED}✗ Failed${COLOR_DEFAULT}: ${label}
     ${COLOR_FAINT}Expected${COLOR_DEFAULT} ${COLOR_BOLD}'${actual}'${COLOR_DEFAULT}
     ${COLOR_FAINT}to not match${COLOR_DEFAULT} ${COLOR_BOLD}'${expected}'${COLOR_DEFAULT}\n"
-      exit 1
-    else
-      ((_TOTAL_ASSERTIONS_PASSED++))
-      printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
-    fi
-  }
+    exit 1
+  else
+    ((_TOTAL_ASSERTIONS_PASSED++))
+    printf "${COLOR_PASSED}✓ Passed${COLOR_DEFAULT}: ${label}\n"
+  fi
 }

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -13,16 +13,21 @@ ${COLOR_FAINT}Total assertions:${COLOR_DEFAULT} ${COLOR_BOLD}${totalAssertions}$
 
   if [ "$totalFailed" -gt 0 ]; then
     printf "${COLOR_FAINT}Total assertions failed:${COLOR_DEFAULT} ${COLOR_BOLD}${COLOR_FAILED}${totalFailed}${COLOR_DEFAULT}\n"
-    _TIME_TERMINATION=$((($(date +%s%N) - $_TIME_START)/1000000))
-    printf "${COLOR_BOLD}%s${COLOR_DEFAULT}\n" "Time taken: ${_TIME_TERMINATION} ms"
+    printExecTime
     exit 1
   else
     printf "${COLOR_ALL_PASSED}All assertions passed.${COLOR_DEFAULT}\n"
   fi
 
-  _TIME_TERMINATION=$((($(date +%s%N) - $_TIME_START)/1000000))
-  printf "${COLOR_BOLD}%s${COLOR_DEFAULT}\n" "Time taken: ${_TIME_TERMINATION} ms"
+  printExecTime
   exit 0
+}
+
+function printExecTime() {
+  if [[ $OS == "Linux" ]]; then
+    _TIME_TERMINATION=$((($(date +%s%N) - $_TIME_START)/1000000))
+    printf "${COLOR_BOLD}%s${COLOR_DEFAULT}\n" "Time taken: ${_TIME_TERMINATION} ms"
+  fi
 }
 
 # Set a trap to call renderResult when the script exits

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -20,6 +20,7 @@ function test_multiple_asserts() {
   assertEquals "1" "1" "1 equals 1"
   assertEquals "2" "2" "2 equals 2"
   assertEquals "3" "3" "3 equals 3"
+  assertEquals "4" "4" "4 equals 4"
 }
 
 function test_successful_assertContains() {

--- a/tests/unit/render_test.sh
+++ b/tests/unit/render_test.sh
@@ -66,9 +66,11 @@ function test_render_time_of_execution_when_all_assertions_passed() {
   local assertions_passed=5
   local assertions_failed=1
 
-  assertMatches\
-    ".*Time taken: [[:digit:]]+ ms"\
-    "$(renderResult $total_tests $assertions_passed $assertions_failed)"
+  if [[ $OS == "Linux" ]]; then
+    assertMatches\
+      ".*Time taken: [[:digit:]]+ ms"\
+      "$(renderResult $total_tests $assertions_passed $assertions_failed)"
+  fi
 }
 
 function test_render_time_of_execution_when_not_all_assertions_passed() {
@@ -76,7 +78,9 @@ function test_render_time_of_execution_when_not_all_assertions_passed() {
   local assertions_passed=5
   local assertions_failed=1
 
-  assertMatches\
-    ".*Time taken: [[:digit:]]+ ms"\
-    "$(renderResult $total_tests $assertions_passed $assertions_failed)"
+  if [[ $OS == "Linux" ]]; then
+    assertMatches\
+      ".*Time taken: [[:digit:]]+ ms"\
+      "$(renderResult $total_tests $assertions_passed $assertions_failed)"
+  fi
 }


### PR DESCRIPTION
## Description

MacOS `date` bash function does not support nanoseconds, therefore the feature that to calculate the time taken to run the tests is not possible to implement 😢 