### PR TITLE
Prevent framework to be broken if there is not a .env file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,6 +33,12 @@ Please post code and output as text ([using proper markup](https://guides.github
 
 Please make sure you have [set up your username and email address](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup) for use with Git. Strings such as `silly nick name <root@localhost>` look really stupid in the commit history of a project.
 
+## Change the configuration
+To change the configuration for the project we use the `.env` file if you would like to know what variables should be there use the following command:
+```bash
+cp .env.example .env
+```
+
 ## Testing
 
 Run tests from the library:
@@ -63,9 +69,17 @@ Installation: https://github.com/koalaman/shellcheck#installing
 make lint
 
 # using shellcheck itself
-shellcheck ./**/*.sh -C
+shellcheck ./**/**/*.sh -C
 ```
 
 #### We recommend
+
+To install the pre-commit of the project with the following command:
+
+**Please note that you will need to have Shellcheck installed on your computer.**
+
+```bash
+make pre_commit/install
+```
 
 [Shell Guide](https://google.github.io/styleguide/shellguide.html#s7.2-variable-names) by Google Conventions.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,7 @@ Replace this text with a short description of your feature/bugfix.
 ## 🔖 Changes
 
 - List individual changes in more detail
+
+## ✅ To-do list
+- [ ] Make sure that all the pipeline passes
+- [ ] Make sure to update the need it documentation files for example: CHANGELOG.md of CONTRIBUTING.md

--- a/.github/workflows/editor_config_lint.yml
+++ b/.github/workflows/editor_config_lint.yml
@@ -14,10 +14,6 @@ jobs:
     name: Editor config lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18.x'
-      - run: npm i -g eclint
-      - run: eclint check 'src/**/**/*'
+      - uses: snow-actions/eclint@v1.0.1
+        env:
+          ALWAYS_LINT_ALL_FILES: true

--- a/.github/workflows/editor_config_lint.yml
+++ b/.github/workflows/editor_config_lint.yml
@@ -1,0 +1,21 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+name: Editor config lint
+
+jobs:
+
+  shellcheck:
+    name: Editor config lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zbeekman/EditorConfig-Action@v1.1.0
+        env:
+          ALWAYS_LINT_ALL_FILES: true
+
+

--- a/.github/workflows/editor_config_lint.yml
+++ b/.github/workflows/editor_config_lint.yml
@@ -10,11 +10,11 @@ name: Editor config lint
 
 jobs:
 
-  shellcheck:
+  editorconfig:
     name: Editor config lint
     runs-on: ubuntu-latest
     steps:
-      - uses: zbeekman/EditorConfig-Action@v1.1.0
+      - uses: snow-actions/eclint@v1.0.1
         env:
           ALWAYS_LINT_ALL_FILES: true
 

--- a/.github/workflows/editor_config_lint.yml
+++ b/.github/workflows/editor_config_lint.yml
@@ -14,8 +14,10 @@ jobs:
     name: Editor config lint
     runs-on: ubuntu-latest
     steps:
-      - uses: snow-actions/eclint@v1.0.1
-        env:
-          ALWAYS_LINT_ALL_FILES: true
-
-
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: npm i eclint
+      - run: eclint check 'src/**/**/*'

--- a/.github/workflows/editor_config_lint.yml
+++ b/.github/workflows/editor_config_lint.yml
@@ -19,5 +19,5 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
-      - run: npm i eclint
+      - run: npm i -g eclint
       - run: eclint check 'src/**/**/*'

--- a/.github/workflows/editor_config_lint.yml
+++ b/.github/workflows/editor_config_lint.yml
@@ -14,6 +14,10 @@ jobs:
     name: Editor config lint
     runs-on: ubuntu-latest
     steps:
-      - uses: snow-actions/eclint@v1.0.1
-        env:
-          ALWAYS_LINT_ALL_FILES: true
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: npm i -g eclint
+      - run: eclint check 'src/**/**/*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,11 @@ jobs:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest']
         include:
           - os: windows-latest
-            script_name: 'cp .env.example .env && bash -c "./bashunit tests/**/*_test.sh"'
+            script_name: 'bash -c "./bashunit tests/**/*_test.sh"'
           - os: ubuntu-latest
-            script_name: 'cp .env.example .env && make test'
+            script_name: 'make test'
           - os: macos-latest
-            script_name: 'cp .env.example .env && make test'
+            script_name: 'make test'
     steps:
       - uses: actions/checkout@v3
       - name: "Tests"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-include .env
+-include .env
 
 OS:=
 ifeq ($(OS),Windows_NT)
@@ -42,7 +42,7 @@ help:
 	@echo "  env/example              Makes a copy of the keys on your .env file"
 	@echo "  pre_commit/install       Installs the pre-commit hook"
 	@echo "  pre_commit/run           Function that will be called when the pre-commit runs"
-	@echo "  lint                     Run shellcheck"
+	@echo "  lint                     Run shellcheck static analysis tool"
 
 SRC_SCRIPTS_DIR=src
 TEST_SCRIPTS_DIR=tests
@@ -71,4 +71,4 @@ pre_commit/install:
 pre_commit/run: test env/example
 
 lint:
-	shellcheck ./**/*.sh -C && echo "Shellcheck: OK!"
+	@shellcheck ./**/*.sh -C && echo "Shellcheck: OK!"

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ pre_commit/install:
 	@echo "Installing pre-commit hooks"
 	cp $(PRE_COMMIT_SCRIPTS_FILE) ./.git/hooks/
 
-pre_commit/run: test env/example
+pre_commit/run: test lint env/example
 
 lint:
-	@shellcheck ./**/*.sh -C && echo "Shellcheck: OK!"
+	@shellcheck ./**/**/*.sh -C && printf "\e[1m\e[32m%s\e[0m\n" "Shellcheck: OK!"

--- a/bashunit
+++ b/bashunit
@@ -2,6 +2,7 @@
 
 readonly BASH_UNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
+source "$BASH_UNIT_ROOT_DIR/src/default_env_config.sh"
 source "$BASH_UNIT_ROOT_DIR/src/env_configuration.sh"
 source "$BASH_UNIT_ROOT_DIR/src/check_os.sh"
 source "$BASH_UNIT_ROOT_DIR/src/colors.sh"

--- a/src/default_env_config.sh
+++ b/src/default_env_config.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 export _DEFAULT_PARALLEL_RUN=false

--- a/src/default_env_config.sh
+++ b/src/default_env_config.sh
@@ -1,0 +1,1 @@
+export _DEFAULT_PARALLEL_RUN=false

--- a/src/env_configuration.sh
+++ b/src/env_configuration.sh
@@ -2,9 +2,9 @@
 
 set -o allexport
 # shellcheck source=/dev/null
-source .env set
+[[ -f ".env" ]] && source .env set
 set +o allexport
 
 if [ -z "$PARALLEL_RUN" ]; then
-  PARALLEL_RUN=false
+  PARALLEL_RUN=_DEFAULT_PARALLEL_RUN
 fi

--- a/src/env_configuration.sh
+++ b/src/env_configuration.sh
@@ -6,5 +6,5 @@ set -o allexport
 set +o allexport
 
 if [ -z "$PARALLEL_RUN" ]; then
-  PARALLEL_RUN=_DEFAULT_PARALLEL_RUN
+  PARALLEL_RUN=$_DEFAULT_PARALLEL_RUN
 fi


### PR DESCRIPTION
## 📚 Description

Prevent that if the project does not have an .env the framework and the make file continue to function normally with the default configuration

## 🔖 Changes

- Load only the `.env` if it exists in bashunit as well as in the Makefile
- Add a file with the default config if the `.env` file does not exist or it is not configured
- Change the pipelines so they do not copy the `.env.example` to the `.env` file
- Added color to the linting output
![image](https://github.com/Chemaclass/bashunit/assets/6353105/2b81cc6b-f02d-4bad-b8c4-5db6f684176f)
- Make the lint part of the `pre_commit/run` command from the `Makefile`
- Update documentation on the `CONTRIBUITING.md` file
- Update the `github/PULL_REQUEST_TEMPLATE.md` file
- Create a GitHub action to run against our `.editorconfig` to lint formatting issues
