### PR TITLE
Add README.md inside docs/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../docs/assets/logo_name_dark.svg">
+    <img alt="bashunit" src="../docs/assets/logo_name.svg" width="400">
+  </picture>
+</p>
+
+A simple testing library for bash scripts.
+
+## Functions
+
+### [Asserts](../src/assert.sh)
+
+- `assertEquals` expected actual message
+- `assertContains` expected actual message
+- `assertNotContains` expected actual message
+- `assertMatches` expected actual message
+- `assertNotMatches` expected actual message
+- `assertExitCode` expected actual message
+
+
+## Example
+
+Check out this [simple example](../example) using **bashunit**, or a more "real" example in the original repository where the idea grew up: [Chemaclass/conventional-commits](https://github.com/Chemaclass/conventional-commits/blob/main/tests/prepare-commit-msg_test.sh).


### PR DESCRIPTION
## 📚 Description

Create a `README.md` to display all assert functions when you go to the `docs/` folder

![Screenshot 2023-09-11 at 14 30 57](https://github.com/Chemaclass/bashunit/assets/5256287/1f56c11b-c6e8-4bb5-b0b6-03bf455e1466)
