### PR TITLE
fix: watch on test

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,13 +44,14 @@ cp .env.example .env
 Run tests from the library:
 ```bash
 # using make
-make test 
+make test
 
 # using bashunit itself
 ./bashunit tests/**/*_test.sh
 ```
 
-Run the test with a watcher:
+Run the test with a watcher for development:
+this will require to have installed [fswatcher](https://github.com/emcrisostomo/fswatch)
 ```bash
 # you have to install `watch` for your OS
 make test/watch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update functional examples
 - Update documentation
 - Add support for the static analysis on Mac OS
+- Fix bug with watcher for the development of bashunit
 
 ### 0.5.0
 ### 2023-09-10

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test: $(TEST_SCRIPTS)
 	./bashunit $(TEST_SCRIPTS)
 
 test/watch: $(TEST_SCRIPTS)
-	watch --color -n 1 ./bashunit $(TEST_SCRIPTS)
+	fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 -I{} ./bashunit $(TEST_SCRIPTS)
 
 env/example:
 	@echo "Copy the .env into the .env.example file without the values"


### PR DESCRIPTION
## 📚 Description
Fix watch to run on file change and allow to scroll on changes the fix should work on all the OS

## 🔖 Changes

- use dependency `fswatch`
- watch all file system and run bashunit in case there is a change, not running the make command because does not work on Windows

## ✅ To-do list
- [X] Make sure that all the pipeline passes
- [X] Make sure to update the need it documentation files for example: CHANGELOG.md of CONTRIBUTING.md